### PR TITLE
Fix issue where domains beginning with "w" have their first letter stripped in the default email address.

### DIFF
--- a/includes/classes/Admin/class-settings-page.php
+++ b/includes/classes/Admin/class-settings-page.php
@@ -473,7 +473,7 @@ if ( ! class_exists( '\WP2FA\Admin\Settings_Page' ) ) {
 			$from_email = 'wp2fa@';
 
 			if ( ! empty( $sitename ) ) {
-				$sitename    = ltrim( $sitename, 'www.' );
+				$sitename    = preg_replace( '/^www\./i', '', $sitename );
 				$from_email .= sanitize_text_field( $sitename );
 			}
 


### PR DESCRIPTION
The default email address in incorrectly calculated by get_default_email_address(), which misuses ltrim to strip "www." from the start of the domain. This means that the default email address for any domain starting with "w" has that first letter stripped, too.

This small fix corrects this issue.